### PR TITLE
Added middleName to class Name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ In Keycloak admin console:
    
        Rp6vMlHPYTHnyucsPvFk8gTzdYtTueMbmVznAtkUKhD9HPcI3bLKDrr0b2mNJLfStsyvhbpyMUIpaffKQcY7IUuM20ecYBjiyjkLuX5eDQUInWUINfCCyXQnNdSU4K1j2z4IJrvacQz1PFrL0Tj4lt72jSxikzMBHWsGdFyT90bx0R26GR4YCudKxltozVrKPsUC1cdy
 
-1. Fill *Team ID* and *Key ID* with corresponding values found in Apple Developper console.
+1. Fill *Team ID* and *Key ID* with corresponding values found in Apple Developer console.
 1. Set Default Scopes to 'openid%20name%20email' to retrieve email, firstname and lastname from apple.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ The present extension addresses all these requirements.
 ## Installation
 
 1. Download the latest release of the provider JAR file [here](https://github.com/BenjaminFavre/keycloak-apple-social-identity-provider/releases).
-2. Install the provider JAR file following Keycloak instructions [there](https://www.keycloak.org/docs/latest/server_development/index.html#using-the-keycloak-deployer).
+1. Install the provider JAR file following Keycloak instructions [there](https://www.keycloak.org/docs/latest/server_development/index.html#using-the-keycloak-deployer).
 
 ## Configuration
 
 In Keycloak admin console:
 1. Add an identity provider and select *Apple*.
-2. Fill *Client secret* with the base 64 content of your private key file (trim delimiters and new lines).
+1. Fill *Client secret* with the base 64 content of your private key file (trim delimiters and new lines).
 
    e.g., if your private key is:
    
@@ -34,4 +34,5 @@ In Keycloak admin console:
    
        Rp6vMlHPYTHnyucsPvFk8gTzdYtTueMbmVznAtkUKhD9HPcI3bLKDrr0b2mNJLfStsyvhbpyMUIpaffKQcY7IUuM20ecYBjiyjkLuX5eDQUInWUINfCCyXQnNdSU4K1j2z4IJrvacQz1PFrL0Tj4lt72jSxikzMBHWsGdFyT90bx0R26GR4YCudKxltozVrKPsUC1cdy
 
-3. Fill *Team ID* and *Key ID* with corresponding values found in Apple Developper console.
+1. Fill *Team ID* and *Key ID* with corresponding values found in Apple Developper console.
+1. Set Default Scopes to 'openid%20name%20email' to retrieve email, firstname and lastname from apple.

--- a/src/main/java/fr/benjaminfavre/provider/AppleIdentityProvider.java
+++ b/src/main/java/fr/benjaminfavre/provider/AppleIdentityProvider.java
@@ -118,12 +118,14 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
         }
     }
 
+
     private static class User {
         public String email;
         public Name name;
 
         private static class Name {
             public String firstName;
+            public String middleName;
             public String lastName;
         }
     }


### PR DESCRIPTION
Apple added the field "middleName" to the json reponse. 

After first authentication an error occured on keycloak server:

`
[0m[31m09:35:52,588 ERROR [org.keycloak.broker.oidc.OIDCIdentityProvider] (default task-1) Failed to parse userJson [{"name":{"firstName":"First","middleName":"","lastName":"Last"},"email":"some@email.de"}]: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "middleName" (class fr.benjaminfavre.provider.AppleIdentityProvider$User$Name), not marked as ignorable (2 known properties: "lastName", "firstName"])
 at [Source: (String)"{"name":{"firstName":"First","middleName":"","lastName":"Last"},"email":"some@email.de"}"; line: 1, column: 44] (through reference chain: fr.benjaminfavre.provider.AppleIdentityProvider$User["name"]->fr.benjaminfavre.provider.AppleIdentityProvider$User$Name["middleName"])`

It was not possible to extract firstName or lastName from the json response. With this PR all works again as expected.

P.S:
I hate apple!