### PR TITLE
Accept full content of private key file in Client Secret field

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ The present extension addresses all these requirements.
 
 In Keycloak admin console:
 1. Add an identity provider and select *Apple*.
-1. Fill *Client secret* with the base 64 content of your private key file (trim delimiters and new lines).
-
-   e.g., if your private key is:
+1. Fill *Client secret* with the content of your private key file, e.g.
    
        -----BEGIN PRIVATE KEY-----
        Rp6vMlHPYTHnyucsPvFk8gTzdYtTueMbmVznAtkUKhD9HPcI3bLKDrr0b2mNJLfS
@@ -30,9 +28,5 @@ In Keycloak admin console:
        PsUC1cdy
        -----END PRIVATE KEY-----
    
-   then you should set *Client secret* with:
-   
-       Rp6vMlHPYTHnyucsPvFk8gTzdYtTueMbmVznAtkUKhD9HPcI3bLKDrr0b2mNJLfStsyvhbpyMUIpaffKQcY7IUuM20ecYBjiyjkLuX5eDQUInWUINfCCyXQnNdSU4K1j2z4IJrvacQz1PFrL0Tj4lt72jSxikzMBHWsGdFyT90bx0R26GR4YCudKxltozVrKPsUC1cdy
-
 1. Fill *Team ID* and *Key ID* with corresponding values found in Apple Developer console.
 1. Set Default Scopes to 'openid%20name%20email' to retrieve email, firstname and lastname from apple.

--- a/src/main/java/fr/benjaminfavre/provider/AppleIdentityProvider.java
+++ b/src/main/java/fr/benjaminfavre/provider/AppleIdentityProvider.java
@@ -67,7 +67,7 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
     public SimpleHttp authenticateTokenRequest(SimpleHttp tokenRequest) {
         AppleIdentityProviderConfig config = (AppleIdentityProviderConfig) getConfig();
         tokenRequest.param(OAUTH2_PARAMETER_CLIENT_ID, config.getClientId());
-        String base64PrivateKey = config.getClientSecret();
+        String base64PrivateKey = config.getClientSecret().replaceAll("[\r\n\t\f ]|-----.+?-----", "");
 
         try {
             KeyFactory keyFactory = KeyFactory.getInstance("EC");


### PR DESCRIPTION
Please accept this humble PR to simplify the configuration and pottentially save hours of others in the future...

After rushing over the setup and spending hours trying to figure out why the login just wouldn't work it turned out that the result of `cat *.p8 | base64 -w 0` just wasn't the value the client secret field expected :facepalm: 

With this PR merged the Client Secret field will accept the full content of the private key file.
Already correctly configured private key fields aren't affected by the change, as their values will survive `replaceAll("[\r\n\t\f ]|-----.+?-----", "")` ([Regex test](https://regex101.com/r/bAFtZD/3)) unharmed.

---

Thank you so much for this extension! :slightly_smiling_face: I'm migrating to it from a custom build keycloak with the [Apple IDP PR](https://github.com/keycloak/keycloak/pull/7323) merged and all i needed to do was replace the client secret field.
The approach with generating the client secret on the fly is neat. Previously it happened that our client secret expired...  