### PR TITLE
Fix 21.0.1 Provider Endpoint Implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <keycloak.version>11.0.2</keycloak.version>
+        <keycloak.version>21.0.1</keycloak.version>
     </properties>
 
     <build>

--- a/src/main/java/fr/benjaminfavre/provider/AppleIdentityProvider.java
+++ b/src/main/java/fr/benjaminfavre/provider/AppleIdentityProvider.java
@@ -42,7 +42,7 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
 
     @Override
     public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
-        return new OIDCEndpoint(callback, realm, event);
+        return new OIDCEndpoint(callback, realm, event, this);
     }
 
     @Override
@@ -104,8 +104,8 @@ public class AppleIdentityProvider extends OIDCIdentityProvider implements Socia
     }
 
     protected class OIDCEndpoint extends OIDCIdentityProvider.OIDCEndpoint {
-        public OIDCEndpoint(AuthenticationCallback callback, RealmModel realm, EventBuilder event) {
-            super(callback, realm, event);
+        public OIDCEndpoint(AuthenticationCallback callback, RealmModel realm, EventBuilder event, OIDCIdentityProvider provider) {
+            super(callback, realm, event, provider);
         }
 
         @POST


### PR DESCRIPTION
Using the newer version of keycloak, causes this error when attempting to login:

<details open>
<summary>Error Message</summary>

```
2023-03-09T09:25:39.983326749Z 2023-03-09 09:25:39,957 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-36) Uncaught server error: java.lang.NoSuchMethodError: 'void org.keycloak.broker.oidc.OIDCIdentityProvider$OIDCEndpoint.<init>(org.keycloak.broker.oidc.OIDCIdentityProvider, org.keycloak.broker.provider.IdentityProvider$AuthenticationCallback, org.keycloak.models.RealmModel, org.keycloak.events.EventBuilder)'
2023-03-09T09:25:39.983384750Z 	at fr.benjaminfavre.provider.AppleIdentityProvider$OIDCEndpoint.<init>(AppleIdentityProvider.java:108)
2023-03-09T09:25:39.983392750Z 	at fr.benjaminfavre.provider.AppleIdentityProvider.callback(AppleIdentityProvider.java:45)
2023-03-09T09:25:39.983397450Z 	at org.keycloak.services.resources.IdentityBrokerService.getEndpoint(IdentityBrokerService.java:419)
2023-03-09T09:25:39.983402150Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-03-09T09:25:39.983406450Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2023-03-09T09:25:39.983410850Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-03-09T09:25:39.983415250Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
2023-03-09T09:25:39.983419650Z 	at org.jboss.resteasy.core.ResourceLocatorInvoker.constructLocator(ResourceLocatorInvoker.java:107)
2023-03-09T09:25:39.983423950Z 	at org.jboss.resteasy.core.ResourceLocatorInvoker.resolveTargetFromLocator(ResourceLocatorInvoker.java:87)
2023-03-09T09:25:39.983428250Z 	at org.jboss.resteasy.core.ResourceLocatorInvoker.invoke(ResourceLocatorInvoker.java:148)
2023-03-09T09:25:39.983432450Z 	at org.jboss.resteasy.core.ResourceLocatorInvoker.invokeOnTargetObject(ResourceLocatorInvoker.java:183)
2023-03-09T09:25:39.983436750Z 	at org.jboss.resteasy.core.ResourceLocatorInvoker.invoke(ResourceLocatorInvoker.java:141)
2023-03-09T09:25:39.983440950Z 	at org.jboss.resteasy.core.ResourceLocatorInvoker.invoke(ResourceLocatorInvoker.java:32)
2023-03-09T09:25:39.983445250Z 	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:492)
2023-03-09T09:25:39.983449450Z 	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:261)
2023-03-09T09:25:39.983453651Z 	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:161)
2023-03-09T09:25:39.983458851Z 	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:364)
2023-03-09T09:25:39.983495651Z 	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:164)
2023-03-09T09:25:39.983500151Z 	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:247)
2023-03-09T09:25:39.983504151Z 	at io.quarkus.resteasy.runtime.standalone.RequestDispatcher.service(RequestDispatcher.java:73)
2023-03-09T09:25:39.983507951Z 	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:151)
2023-03-09T09:25:39.983511951Z 	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.handle(VertxRequestHandler.java:82)
2023-03-09T09:25:39.983515851Z 	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.handle(VertxRequestHandler.java:42)
2023-03-09T09:25:39.983520051Z 	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1284)
2023-03-09T09:25:39.983523951Z 	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:173)
2023-03-09T09:25:39.983527751Z 	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:140)
2023-03-09T09:25:39.983531751Z 	at io.quarkus.vertx.http.runtime.StaticResourcesRecorder$2.handle(StaticResourcesRecorder.java:84)
2023-03-09T09:25:39.983535651Z 	at io.quarkus.vertx.http.runtime.StaticResourcesRecorder$2.handle(StaticResourcesRecorder.java:71)
2023-03-09T09:25:39.983539651Z 	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1284)
2023-03-09T09:25:39.983543551Z 	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:173)
2023-03-09T09:25:39.983547451Z 	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:140)
2023-03-09T09:25:39.983551252Z 	at io.quarkus.vertx.http.runtime.VertxHttpRecorder$6.handle(VertxHttpRecorder.java:430)
2023-03-09T09:25:39.983555252Z 	at io.quarkus.vertx.http.runtime.VertxHttpRecorder$6.handle(VertxHttpRecorder.java:408)
2023-03-09T09:25:39.983559152Z 	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1284)
2023-03-09T09:25:39.983562952Z 	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:173)
2023-03-09T09:25:39.983566852Z 	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:140)
2023-03-09T09:25:39.983570852Z 	at org.keycloak.quarkus.runtime.integration.web.QuarkusRequestFilter.lambda$createBlockingHandler$0(QuarkusRequestFilter.java:82)
2023-03-09T09:25:39.983574852Z 	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:576)
2023-03-09T09:25:39.983578752Z 	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
2023-03-09T09:25:39.983583052Z 	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
2023-03-09T09:25:39.983587052Z 	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
2023-03-09T09:25:39.983595052Z 	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
2023-03-09T09:25:39.983599052Z 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2023-03-09T09:25:39.983602952Z 	at java.base/java.lang.Thread.run(Thread.java:833)
```
</details>

This just adds the link in between `AppleIdentityProvider` and `OIDCEndpoint` as required.